### PR TITLE
Feat: add streamlit front-end

### DIFF
--- a/app-folder/requirements.txt
+++ b/app-folder/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 gensim
 spacy
 numpy
+streamlit


### PR DESCRIPTION
This adds the streamlit front-end to the app.

I haven't removed the old html here, and also I haven't hooked this up to the docker instance for now. This just adds the streamlit side of things.

To run this you need to install streamlit:

```bash
$ pip install streamlit
$ streamlit run semantic_app.py
```